### PR TITLE
feat(web): <UtilityBar /> shell primitive (story B.1)

### DIFF
--- a/apps/web/src/lib/components/shell/UtilityBar.svelte
+++ b/apps/web/src/lib/components/shell/UtilityBar.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { breadcrumb, rightSlot }: { breadcrumb: string[]; rightSlot?: Snippet } = $props();
+</script>
+
+<div class="utility-bar">
+	<div class="utility-left">
+		{#each breadcrumb as seg, i}
+			<span class="crumb">{seg}</span>
+			{#if i < breadcrumb.length - 1}
+				<span class="sep" aria-hidden="true">·</span>
+			{/if}
+		{/each}
+	</div>
+	<div class="utility-right">
+		{@render rightSlot?.()}
+	</div>
+</div>
+
+<style>
+	.utility-bar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		height: 36px;
+		box-sizing: border-box;
+		padding: 0 var(--space-24);
+		background: var(--wired-black);
+		color: var(--paper-white);
+		font-family: var(--font-sans);
+		font-size: 14px;
+		text-transform: uppercase;
+		letter-spacing: 0.92px;
+		border-radius: 0;
+	}
+
+	.utility-left {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+	}
+
+	.utility-left .sep {
+		margin: 0 var(--space-8);
+		user-select: none;
+	}
+
+	.utility-right {
+		display: flex;
+		align-items: center;
+		height: 100%;
+	}
+
+	/* Links are authored by the caller via rightSlot, so they live outside this
+	   component's scope — target them with :global() inside the scoped wrapper. */
+	.utility-right :global(a) {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		height: 100%;
+		padding: 0 var(--space-16);
+		color: var(--paper-white);
+		text-decoration: none;
+		transition: color 120ms;
+	}
+
+	.utility-right :global(a:first-child) {
+		padding-left: 0;
+	}
+
+	.utility-right :global(a:last-child) {
+		padding-right: 0;
+	}
+
+	.utility-right :global(a:hover) {
+		color: var(--link-blue);
+	}
+
+	.utility-right :global(a + a)::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 1px;
+		height: 20px;
+		background: rgba(255, 255, 255, 0.3);
+	}
+</style>

--- a/apps/web/src/lib/components/shell/__tests__/UtilityBar.test.ts
+++ b/apps/web/src/lib/components/shell/__tests__/UtilityBar.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import UtilityBar from '../UtilityBar.svelte';
+import UtilityBarHarness from './UtilityBarHarness.svelte';
+
+describe('UtilityBar', () => {
+	test('renders all breadcrumb segments in array order', () => {
+		const breadcrumb = ['Cuatro Library', 'Libraries', 'Sci-Fi'];
+		const { container } = render(UtilityBar, { breadcrumb });
+
+		const crumbs = [...container.querySelectorAll('.crumb')].map((el) => el.textContent);
+		expect(crumbs).toEqual(breadcrumb);
+	});
+
+	test('puts a · separator between segments (count === segments - 1)', () => {
+		const breadcrumb = ['Cuatro Library', 'Libraries', 'Sci-Fi'];
+		const { container } = render(UtilityBar, { breadcrumb });
+
+		const seps = [...container.querySelectorAll('[aria-hidden="true"]')];
+		expect(seps.length).toBe(breadcrumb.length - 1);
+		expect(seps.every((s) => s.textContent === '·')).toBe(true);
+	});
+
+	test('a single-segment breadcrumb renders no separators', () => {
+		const { container } = render(UtilityBar, { breadcrumb: ['Cuatro Library'] });
+		expect(container.querySelectorAll('[aria-hidden="true"]').length).toBe(0);
+	});
+
+	test('renders rightSlot content into the right region', () => {
+		const { container } = render(UtilityBarHarness, { breadcrumb: ['Cuatro Library'] });
+
+		const links = [...container.querySelectorAll('.utility-right a')];
+		expect(links.length).toBe(2);
+		expect(links.map((a) => a.textContent?.trim())).toEqual(['Settings', 'Log out']);
+	});
+});

--- a/apps/web/src/lib/components/shell/__tests__/UtilityBarHarness.svelte
+++ b/apps/web/src/lib/components/shell/__tests__/UtilityBarHarness.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import UtilityBar from '../UtilityBar.svelte';
+
+	let { breadcrumb }: { breadcrumb: string[] } = $props();
+</script>
+
+<UtilityBar {breadcrumb}>
+	{#snippet rightSlot()}
+		<a href="/settings">Settings</a>
+		<a href="/logout">Log out</a>
+	{/snippet}
+</UtilityBar>

--- a/apps/web/src/lib/tokens.css
+++ b/apps/web/src/lib/tokens.css
@@ -2,6 +2,9 @@
   --page-ink: #1a1a1a;
   --caption-gray: #757575;
   --link-blue: #057dbc;
+  --wired-black: #000000;
+  --paper-white: #ffffff;
+  --hairline-tint: #e2e8f0;
 
   --font-display: 'Playfair Display', Georgia, serif;
   --font-serif: 'Source Serif 4', Georgia, serif;

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { svelteTesting } from '@testing-library/svelte/vite';
 import path from 'path';
 
 export default defineConfig({
-  plugins: [svelte({ hot: !process.env.VITEST })],
+  plugins: [svelte({ hot: !process.env.VITEST }), svelteTesting()],
   resolve: {
     alias: {
       '$lib': path.resolve('./src/lib'),


### PR DESCRIPTION
## Story B.1 — `<UtilityBar />` (Epic 02: Shared UI Primitives)

The WIRED black 36px utility strip: ordered breadcrumb with middle-dot (`·`) separators on the left, and a `rightSlot` snippet for session links on the right (1px `rgba(255,255,255,0.3)` hairline dividers between adjacent links, `--link-blue` hover over 120ms). Scoped `<style>` + `var(--…)` only — no Tailwind utilities (Epic 02 Risk #2). Additive: **not** wired into any layout yet (that is Epic 03).

### Changes
- `apps/web/src/lib/components/shell/UtilityBar.svelte` — new primitive (Svelte 5 runes, `Snippet` prop, `{@render rightSlot?.()}`)
- `…/shell/__tests__/UtilityBar.test.ts` (+ `UtilityBarHarness.svelte`) — 4 component tests via `@testing-library/svelte`
- `apps/web/src/lib/tokens.css` — add `--wired-black` / `--paper-white` / `--hairline-tint` (Epic 02 token top-up)
- `apps/web/vitest.config.ts` — add `svelteTesting()` so component-render tests resolve Svelte''s browser build

### Verification
- `pnpm --filter @digital-library/web test` — 35/35 pass (4 new)
- `pnpm --filter @digital-library/web typecheck` — 0 errors / 0 warnings
- `pnpm --filter @digital-library/web build` — OK (adapter-node)

### Review
Passed the full 3-layer adversarial review — clean against all 9 acceptance criteria. Non-blocking deferred follow-ups (tracked in `deferred-work.md`):
- The `a + a` hairline divider won''t render once the bar is wired to the real `<span>` email + `<form>` sign-out strip — address in the Epic 03 wiring.
- Breadcrumb a11y polish (`<nav aria-label>` + `aria-current`), long-segment truncation, and a vitest version-split cleanup.