### PR TITLE
feat(web): add <Footer /> shell primitive (story B.3)

### DIFF
--- a/apps/web/src/lib/components/shell/Footer.svelte
+++ b/apps/web/src/lib/components/shell/Footer.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	let { isAdmin = false }: { isAdmin?: boolean } = $props();
+
+	const links = $derived([
+		{ label: 'GITHUB', href: 'https://github.com/LuigiEspinosa/digital-library', external: true },
+		{ label: 'DOCS', href: '/docs', external: false },
+		...(isAdmin ? [{ label: 'ADMIN', href: '/admin', external: false }] : [])
+	]);
+</script>
+
+<div class="footer">
+	<p class="wordmark">CUATRO LIBRARY</p>
+	<div class="footer-links">
+		{#each links as link, i}
+			<a
+				href={link.href}
+				target={link.external ? '_blank' : undefined}
+				rel={link.external ? 'noopener noreferrer' : undefined}>{link.label}</a>
+			{#if i < links.length - 1}
+				<span class="sep" aria-hidden="true">·</span>
+			{/if}
+		{/each}
+	</div>
+</div>
+
+<style>
+	.footer {
+		width: 100%;
+		background: var(--page-ink);
+		padding: var(--space-48) 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		border-radius: 0;
+	}
+
+	.wordmark {
+		font-family: var(--font-display);
+		font-size: 32px;
+		color: var(--paper-white);
+		margin: 0;
+	}
+
+	.footer-links {
+		margin-top: var(--space-16);
+		display: flex;
+		align-items: center;
+	}
+
+	/* Footer renders its own GITHUB/DOCS/ADMIN anchors, so they sit inside this
+	   component's style scope — plain .footer-links a, not the :global() the slot
+	   links in UtilityBar/AppNav need. */
+	.footer-links a {
+		font-family: var(--font-sans);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.92px;
+		color: var(--paper-white);
+		text-decoration: none;
+		transition: color 120ms;
+	}
+
+	.footer-links a:hover {
+		color: var(--link-blue);
+	}
+
+	.footer-links .sep {
+		margin: 0 var(--space-8);
+		color: var(--paper-white);
+		user-select: none;
+	}
+</style>

--- a/apps/web/src/lib/components/shell/__tests__/Footer.test.ts
+++ b/apps/web/src/lib/components/shell/__tests__/Footer.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import Footer from '../Footer.svelte';
+
+const REPO_URL = 'https://github.com/LuigiEspinosa/digital-library';
+
+describe('Footer', () => {
+	test('wordmark is the fixed CUATRO LIBRARY text and not a link', () => {
+		const { container } = render(Footer, { isAdmin: false });
+		const wordmark = container.querySelector('.wordmark');
+
+		expect(wordmark?.textContent).toBe('CUATRO LIBRARY');
+		expect(wordmark?.tagName).not.toBe('A');
+		expect(wordmark?.getAttribute('href')).toBe(null);
+	});
+
+	test('default (no props) shows GITHUB · DOCS — two links, one separator, no ADMIN', () => {
+		const { container } = render(Footer, {});
+
+		const labels = [...container.querySelectorAll('.footer-links a')].map((a) => a.textContent?.trim());
+		expect(labels).toEqual(['GITHUB', 'DOCS']);
+
+		const seps = [...container.querySelectorAll('.footer-links [aria-hidden="true"]')];
+		expect(seps.length).toBe(1);
+		expect(seps.every((s) => s.textContent === '·')).toBe(true);
+	});
+
+	test('isAdmin: false shows exactly GITHUB · DOCS', () => {
+		const { container } = render(Footer, { isAdmin: false });
+
+		const labels = [...container.querySelectorAll('.footer-links a')].map((a) => a.textContent?.trim());
+		expect(labels).toEqual(['GITHUB', 'DOCS']);
+		expect(container.querySelectorAll('.footer-links [aria-hidden="true"]').length).toBe(1);
+	});
+
+	test('isAdmin: true shows GITHUB · DOCS · ADMIN — three links, two separators', () => {
+		const { container } = render(Footer, { isAdmin: true });
+
+		const labels = [...container.querySelectorAll('.footer-links a')].map((a) => a.textContent?.trim());
+		expect(labels).toEqual(['GITHUB', 'DOCS', 'ADMIN']);
+		expect(container.querySelectorAll('.footer-links [aria-hidden="true"]').length).toBe(2);
+	});
+
+	test('GITHUB anchor points at the canonical repo URL', () => {
+		const { container } = render(Footer, { isAdmin: true });
+
+		const github = [...container.querySelectorAll('.footer-links a')].find(
+			(a) => a.textContent?.trim() === 'GITHUB'
+		);
+		expect(github?.getAttribute('href')).toBe(REPO_URL);
+	});
+
+	test('GITHUB is external — target="_blank" + rel="noopener noreferrer"', () => {
+		const { container } = render(Footer, { isAdmin: true });
+
+		const github = [...container.querySelectorAll('.footer-links a')].find(
+			(a) => a.textContent?.trim() === 'GITHUB'
+		);
+		expect(github?.getAttribute('target')).toBe('_blank');
+		expect(github?.getAttribute('rel')).toBe('noopener noreferrer');
+	});
+
+	test('internal DOCS/ADMIN links use provisional hrefs and carry no target/rel', () => {
+		const { container } = render(Footer, { isAdmin: true });
+		const byLabel = (label: string) =>
+			[...container.querySelectorAll('.footer-links a')].find((a) => a.textContent?.trim() === label);
+
+		const docs = byLabel('DOCS');
+		expect(docs?.getAttribute('href')).toBe('/docs');
+		expect(docs?.getAttribute('target')).toBe(null);
+		expect(docs?.getAttribute('rel')).toBe(null);
+
+		const admin = byLabel('ADMIN');
+		expect(admin?.getAttribute('href')).toBe('/admin');
+		expect(admin?.getAttribute('target')).toBe(null);
+		expect(admin?.getAttribute('rel')).toBe(null);
+	});
+
+	test('toggling isAdmin reconciles the link/separator set (2 ↔ 3)', async () => {
+		const { container, rerender } = render(Footer, { isAdmin: false });
+
+		const labels = () =>
+			[...container.querySelectorAll('.footer-links a')].map((a) => a.textContent?.trim());
+		const sepCount = () =>
+			container.querySelectorAll('.footer-links [aria-hidden="true"]').length;
+
+		expect(labels()).toEqual(['GITHUB', 'DOCS']);
+		expect(sepCount()).toBe(1);
+
+		await rerender({ isAdmin: true });
+		expect(labels()).toEqual(['GITHUB', 'DOCS', 'ADMIN']);
+		expect(sepCount()).toBe(2);
+
+		await rerender({ isAdmin: false });
+		expect(labels()).toEqual(['GITHUB', 'DOCS']);
+		expect(sepCount()).toBe(1);
+	});
+});


### PR DESCRIPTION
## Story B.3 - `<Footer />` shell primitive (Epic 02)

Adds the WIRED inverted footer block as a reusable Svelte 5 (runes) shell primitive, joining `UtilityBar` (B.1) and `AppNav` (B.2) under `components/shell/`. Not wired into any page yet - Epic 03 assembles the shell.

### What it does
- Full-bleed `--page-ink` (#1a1a1a) inverted surface, 48px vertical padding, centered vertical stack, square corners, zero shadow.
- Centered Playfair `CUATRO LIBRARY` wordmark - plain text, **not** a link.
- Tertiary links `GITHUB . DOCS . ADMIN` (Inter 11px, uppercase, 0.92px tracking), U+00B7 `aria-hidden` separators, hover -> `--link-blue` over 120ms (color only).
- `ADMIN` gated on the sole prop `isAdmin?: boolean` via `$derived`.
- `GITHUB` -> repo URL, external (`target="_blank"` + `rel="noopener noreferrer"`); `DOCS`/`ADMIN` internal (provisional `/docs`, `/admin`, finalized in Epic 03).
- Component-owned links styled with scoped `.footer-links a` (no `:global`); no token top-up.

### Tests and gates
- `Footer.test.ts` - 8 jsdom tests (wordmark-not-a-link; link/separator counts for isAdmin true/false/default; GITHUB href; external target/rel; internal links carry neither; runtime isAdmin toggle reconciliation).
- `pnpm --filter @digital-library/web test` - 46 pass
- `pnpm --filter @digital-library/web typecheck` - 0 errors / 0 warnings
- `pnpm --filter @digital-library/web build` - green
- web project green under root `vitest.workspace.ts`
- Caveat: root `pnpm test` is red ONLY on `@digital-library/api` due to the documented local better-sqlite3/MSVC native-binding gap (Node 24 locally vs pinned 22); B.3 touches zero api files and the api suite is green on CI/Linux.

### Review
Adversarial code review (Blind Hunter + Edge Case Hunter + Acceptance Auditor): implementation correct against all 9 ACs. The two test-coverage patches (external/internal link attributes; isAdmin toggle reconciliation) were applied before this PR.