### PR TITLE
feat(web): add <HardRule /> primitive (story B.4)

### DIFF
--- a/apps/web/src/lib/components/primitives/HardRule.svelte
+++ b/apps/web/src/lib/components/primitives/HardRule.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { weight = 'rule', ariaLabel, children }: {
+		weight?: 'hairline' | 'rule' | 'bracket' | 'ribbon';
+		ariaLabel?: string;
+		children?: Snippet;
+	} = $props();
+</script>
+
+{#if weight === 'ribbon'}
+	<div class="hard-rule ribbon" role="separator" aria-label={ariaLabel}>
+		<span class="ribbon-text">{@render children?.()}</span>
+	</div>
+{:else}
+	<hr class="hard-rule {weight}" />
+{/if}
+
+<style>
+	/* Reset the UA <hr> default border + ~8px margins first; without it the 1px
+	   weights render doubled and won't match DESIGN.md §6. */
+	.hard-rule {
+		border: 0;
+		margin: 0;
+		border-radius: 0;
+	}
+
+	hr.hard-rule {
+		width: 100%;
+	}
+
+	.hairline {
+		border-top: 1px solid var(--hairline-tint);
+	}
+
+	.rule {
+		border-top: 1px solid var(--wired-black);
+	}
+
+	.bracket {
+		border-top: 2px solid var(--wired-black);
+	}
+
+	.ribbon {
+		width: 100%;
+		height: 36px;
+		background: var(--wired-black);
+		display: flex;
+		align-items: center;
+		padding: 0 var(--space-24);
+		box-sizing: border-box;
+	}
+
+	/* The ribbon label is this component's own element, so the §3 Section Ribbon
+	   type flows into it directly — no :global (unlike the slot links in
+	   UtilityBar/AppNav, which are caller-authored). */
+	.ribbon-text {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		font-weight: 700;
+		line-height: 1;
+		letter-spacing: 1.2px;
+		text-transform: uppercase;
+		color: var(--paper-white);
+	}
+</style>

--- a/apps/web/src/lib/components/primitives/__tests__/HardRule.test.ts
+++ b/apps/web/src/lib/components/primitives/__tests__/HardRule.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import HardRule from '../HardRule.svelte';
+import HardRuleHarness from './HardRuleHarness.svelte';
+
+// jsdom does no layout and does not compute scoped <style>, so we assert the
+// weight->element+class mapping (the testable proxy) — never computed
+// width/height/color/font. The actual §6 pixels/fills are a visual-check item.
+describe('HardRule', () => {
+	test('default weight is an <hr> carrying the "rule" class', () => {
+		const { container } = render(HardRule);
+		const el = container.querySelector('.hard-rule');
+		expect(el?.tagName).toBe('HR');
+		expect(el?.classList.contains('rule')).toBe(true);
+	});
+
+	test('weight="hairline" renders an <hr> with the hairline class', () => {
+		const { container } = render(HardRule, { weight: 'hairline' });
+		const el = container.querySelector('.hard-rule');
+		expect(el?.tagName).toBe('HR');
+		expect(el?.classList.contains('hairline')).toBe(true);
+	});
+
+	test('weight="bracket" renders an <hr> with the bracket class', () => {
+		const { container } = render(HardRule, { weight: 'bracket' });
+		const el = container.querySelector('.hard-rule');
+		expect(el?.tagName).toBe('HR');
+		expect(el?.classList.contains('bracket')).toBe(true);
+	});
+
+	test('non-ribbon weights expose no role or aria-label, even when ariaLabel is passed', () => {
+		const { container } = render(HardRule, { weight: 'rule', ariaLabel: 'ignored' });
+		const el = container.querySelector('.hard-rule');
+		expect(el?.tagName).toBe('HR');
+		expect(el?.hasAttribute('role')).toBe(false);
+		expect(el?.hasAttribute('aria-label')).toBe(false);
+	});
+
+	test('weight="ribbon" renders a <div role="separator"> with aria-label, not an <hr>', () => {
+		const { container } = render(HardRule, { weight: 'ribbon', ariaLabel: 'Most Popular' });
+		const el = container.querySelector('.hard-rule');
+		expect(el?.tagName).toBe('DIV');
+		expect(el?.getAttribute('role')).toBe('separator');
+		expect(el?.getAttribute('aria-label')).toBe('Most Popular');
+	});
+
+	test('ribbon with no ariaLabel emits no aria-label attribute', () => {
+		const { container } = render(HardRule, { weight: 'ribbon' });
+		const el = container.querySelector('.hard-rule');
+		expect(el?.tagName).toBe('DIV');
+		expect(el?.hasAttribute('aria-label')).toBe(false);
+	});
+
+	test('ribbon renders its slotted label text inside .ribbon-text', () => {
+		const { container } = render(HardRuleHarness);
+		expect(container.querySelector('.ribbon-text')?.textContent).toBe('Most Popular');
+	});
+});

--- a/apps/web/src/lib/components/primitives/__tests__/HardRuleHarness.svelte
+++ b/apps/web/src/lib/components/primitives/__tests__/HardRuleHarness.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import HardRule from '../HardRule.svelte';
+</script>
+
+<HardRule weight="ribbon" ariaLabel="Most Popular">Most Popular</HardRule>


### PR DESCRIPTION
Story **B.4** — adds `<HardRule />`, the first `components/primitives/` member.

Four WIRED depth weights per DESIGN.md §6:
- `hairline` — 1px `--hairline-tint` `<hr>`
- `rule` — 1px `--wired-black` `<hr>` (**default**)
- `bracket` — 2px `--wired-black` `<hr>`
- `ribbon` — 36px `--wired-black` bar: `<div role="separator" aria-label>` wrapping a self-styled mono-caps `--paper-white` label (DESIGN.md §3 Section Ribbon)

Svelte 5 runes; scoped `<style>` + `var(--…)` only. No token top-up. Ribbon self-styles its label and does **not** import the unbuilt B.5 `<MonoKicker>` (forward reference, as B.2 skipped B.12). No `:global`, no shadow/radius/hover/transition — purely presentational.

**Tests:** `HardRule.test.ts` — 7 plain-DOM tests (weight→element/class mapping; ribbon role/aria-label, incl. omitted-when-absent and ignored-on-non-ribbon; slot text via `HardRuleHarness.svelte`).

**Code review:** clean PASS — 3-layer adversarial (Blind Hunter + Edge Case Hunter + Acceptance Auditor), all 8 ACs met, 0 violations. 1 test-coverage patch applied (non-ribbon weights emit no role/aria-label); 3 a11y/compose items deferred to Epic 03.

**Gates:** web vitest 53 pass / typecheck 0-0 / build green / web project green under root `pnpm test` (vitest.workspace.ts). (API red locally only on the documented `better-sqlite3`/MSVC native-binding gap — 0 API files touched.)